### PR TITLE
Fix issue adding await to cookies request

### DIFF
--- a/src/payload/getPayloadUser.ts
+++ b/src/payload/getPayloadUser.ts
@@ -31,7 +31,7 @@ export const getPayloadUser = async <T extends object = User>({
     );
   }
 
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
 
   const meUserReq = await fetch(`${serverUrl}/api/${userCollectionSlug}/me`, {
     headers: {


### PR DESCRIPTION
I've found this error and the solution for it

`Error: Route "/" used `cookies().toString()` or implicit casting. `cookies()` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
`

The solution is as simple as await to the cookies().