### PR TITLE
fix: issue on building inside docker image without .env (moved envs from default value at params)

### DIFF
--- a/src/payload/getPayloadUser.ts
+++ b/src/payload/getPayloadUser.ts
@@ -21,9 +21,11 @@ interface Options {
  * Get the user payload from the server (only works on the server side)
  */
 export const getPayloadUser = async <T extends object = User>({
-  serverUrl = process.env.NEXT_PUBLIC_SERVER_URL,
+  serverUrl,
   userCollectionSlug = "users",
 }: Options = {}): Promise<T | null> => {
+  serverUrl = serverUrl || process.env.NEXT_PUBLIC_SERVER_URL
+  
   if (serverUrl === undefined) {
     throw new Error(
       "getPayloadUser requires a server URL to be provided, either as an option or in the 'NEXT_PUBLIC_SERVER_URL' environment variable",


### PR DESCRIPTION
Hi sir

This error only happends when you try to build the code without all the .env variable, for example, inside docker image could happen. The best way to avoid it is to not setting a process.env as a default param.

I make some tests and this will fix the issue. It only happends if you load this code from node modules package. This issue happends to me inside docker build only, but the solution is as easy as it.

` 36.94 server:build:    Generating static pages (0/10) ... 37.77 server:build: Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error **37.77 server:build: Error: getPayloadUser requires a server URL to be provided, either as an option or in the 'NEXT_PUBLIC_SERVER_URL' environment variable** 37.77 server:build:     at d (/app/apps/server/.next/server/chunks/3853.js:604:229796) 37.77 server:build:     at f (/app/apps/server/.next/server/chunks/2196.js:1:6719) 37.77 server:build:     at ek (/app/node_modules/.pnpm/next@15.0.1_@opentelemetry+api@1.9.0_@playwright+test@1.48.0_babel-plugin-react-compiler@0.0._rsqjemyostbi4mzxu4v37fu6p4/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:84:13409) 37.77 server:build:     at e (/app/node_modules/.pnpm/next@15.0.1_@opentelemetry+api@1.9.0_@playwright+test@1.48.0_babel-plugin-react-compiler@0.0._rsqjemyostbi4mzxu4v37fu6p4/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:84:17307) 37.77 server:build:     at eO (/app/node_modules/.pnpm/next@15.0.1_@opentelemetry+api@1.9.0_@playwright+test@1.48.0_babel-plugin-react-compiler@0.0._rsqjemyostbi4mzxu4v37fu6p4/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:84:17769) 37.77 server:build:     at Array.toJSON (/app/node_modules/.pnpm/next@15.0.1_@opentelemetry+api@1.9.0_@playwright+test@1.48.0_babel-plugin-react-compiler@0.0._rsqjemyostbi4mzxu4v37fu6p4/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:84:14915) 37.77 server:build:     at stringify (<anonymous>) 37.77 server:build:     at eU (/app/node_modules/.pnpm/next@15.0.1_@opentelemetry+api@1.9.0_@playwright+test@1.48.0_babel-plugin-react-compiler@0.0._rsqjemyostbi4mzxu4v37fu6p4/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:84:26272) 37.77 server:build:     at eq (/app/node_modules/.pnpm/next@15.0.1_@opentelemetry+api@1.9.0_@playwright+test@1.48.0_babel-plugin-react-compiler@0.0._rsqjemyostbi4mzxu4v37fu6p4/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:84:26502) 37.77 server:build:     at eB (/app/node_modules/.pnpm/next@15.0.1_@opentelemetry+api@1.9.0_@playwright+test@1.48.0_babel-plugin-react-compiler@0.0._rsqjemyostbi4mzxu4v37fu6p4/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:84:27056) 37.77 server:build: Export encountered an error on /(web)/page: /, exiting the build. 37.78 server:build:  ⨯ Static worker exited with code: 1 and signal: null 37.87 server:build:  ELIFECYCLE  Command failed with exit code 1. 37.88 server:build: ERROR: command finished with error: command (/app/apps/server) /usr/local/bin/pnpm run build exited (1) 37.88 server#build: command (/app/apps/server) /usr/local/bin/pnpm run build exited (1)`